### PR TITLE
fix(img): guard processing pipeline against non-raster resources

### DIFF
--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -7,7 +7,7 @@
 
 <figure style="text-align: center;">
   <picture>
-    {{- if $image -}}
+    {{- if and $image $image.Width -}}
       {{- $w600  := math.Min 600 $image.Width | int -}}
       {{- $w900  := math.Min 900 $image.Width | int -}}
       {{- $r600  := $image.Resize (printf "%dx" $w600) -}}


### PR DESCRIPTION
## Summary

- `img.html` shortcode: change `if $image` to `if and $image $image.Width` so SVG and other non-raster page-bundle assets fall through to the plain `<img>` fallback instead of hitting `.Resize`/`.Process` calls that would error at build time
- SVGs return `Width = 0` in Hugo, making this a portable check that doesn't rely on version-specific `reflect` functions

## Test plan

- [ ] `hugo --minify` completes without errors
- [ ] Posts with PNG/WebP page-bundle images still render AVIF + WebP `<picture>` elements
- [ ] A post with an SVG page-bundle image renders a plain `<img>` tag (graceful fallback)