### PR TITLE
fix(blog): repair broken links across Agentic AI series

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,19 @@ Theme shortcodes (from `themes/hugo-clarity/`):
 - **Menus:** Per-language in `config/_default/menus/`
 - **Deployment:** GitHub Actions (`.github/workflows/gh-pages.yaml`) auto-deploys `main` to GitHub Pages using Hugo 0.139.0 extended
 
+## Internal links / URL conventions
+
+English is the default language and is served at the **site root**, not under `/en/`. French is served under `/fr/`. So content files map to live URLs like this:
+
+- `content/en/post/foo/index.md` → `https://blog.ogenki.io/post/foo/` (NOT `/en/post/foo/`)
+- `content/fr/post/foo/index.md` → `https://blog.ogenki.io/fr/post/foo/`
+
+When writing internal links inside Markdown:
+- English posts: use `/post/...` paths (root-relative, no `/en/` prefix). `/en/post/...` returns 404.
+- French posts: use `/fr/post/...` paths.
+
+`aliases` entries that begin with `/en/post/...` are intentional historical redirects (set up before the default language moved to root) — leave them alone.
+
 ## Series
 
 Series group related posts under `post/series/<series-name>/`. Each series has its own `_index.md`. Example series: `observability`, `agentic_ai`, `workshop_helm`, `workshop_kubernetes`. French series live under `content/fr/post/series/`, English under `content/en/post/series/`.

--- a/content/en/post/series/agentic_ai/ai-coding-agent/index.md
+++ b/content/en/post/series/agentic_ai/ai-coding-agent/index.md
@@ -350,7 +350,7 @@ For [cloud-native-ref](https://github.com/Smana/cloud-native-ref), I created a v
 | **Security** | Zero-trust, least privilege, externalized secrets |
 | **SRE** | Health probes, observability, failure modes |
 
-**⚡ Claude Code Skills** — The workflow is orchestrated by [skills](/en/post/series/agentic_ai/ai-coding-agent/#skills-unlocking-new-powers) (see previous section) that automate each step:
+**⚡ Claude Code Skills** — The workflow is orchestrated by [skills](/post/series/agentic_ai/ai-coding-agent/#skills-unlocking-new-powers) (see previous section) that automate each step:
 
 | Skill | Action |
 |-------|--------|

--- a/content/en/post/series/agentic_ai/ai-coding-tips/index.md
+++ b/content/en/post/series/agentic_ai/ai-coding-tips/index.md
@@ -14,7 +14,7 @@ thumbnail = "thumbnail.png"
 +++
 
 {{% notice info "Agentic AI Series — Part 2" %}}
-This article follows [Agentic Coding: concepts and hands-on use cases](/en/post/series/agentic_ai/ai-coding-agent/), where we explored the fundamentals of agentic AI — tokens, MCPs, Skills, Tasks — and two detailed practical examples. **Here, we dive into advanced practices**: how to get the most out of Claude Code on a daily basis.
+This article follows [Agentic Coding: concepts and hands-on use cases](/post/series/agentic_ai/ai-coding-agent/), where we explored the fundamentals of agentic AI — tokens, MCPs, Skills, Tasks — and two detailed practical examples. **Here, we dive into advanced practices**: how to get the most out of Claude Code on a daily basis.
 {{% /notice %}}
 
 As with any tool you adopt, it takes time to refine how you use it. After iterating on my config and workflows, I've found an efficient rhythm with Claude Code. Here's what works for me.
@@ -51,7 +51,7 @@ Here's what the `CLAUDE.md` for [cloud-native-ref](https://github.com/Smana/clou
 - **Architecture summary** — key folder structure, not a novel
 - **Common pitfalls** — traps Claude keeps falling into if you don't warn it (e.g., wrong default namespace, label format)
 
-What I **don't** put in it: exhaustive documentation (that's what [Skills](/en/post/series/agentic_ai/ai-coding-agent/#skills-unlocking-new-powers) are for), long code examples (I reference existing files instead), and obvious instructions Claude already knows.
+What I **don't** put in it: exhaustive documentation (that's what [Skills](/post/series/agentic_ai/ai-coding-agent/#skills-unlocking-new-powers) are for), long code examples (I reference existing files instead), and obvious instructions Claude already knows.
 
 Here's a condensed excerpt from the `CLAUDE.md` of [cloud-native-ref](https://github.com/Smana/cloud-native-ref) to illustrate:
 
@@ -383,7 +383,7 @@ The **correction spiral** is by far the most dangerous. A real example: Claude w
 
 Over time, I've become increasingly comfortable with Claude Code, and the productivity gains are real. But they come with a lingering concern I can't fully shake: losing control — over the produced code, over the decisions made, over the understanding of what's running in production.
 
-These questions, as well as the methods that help me stay in control, are covered in the first article of this series. If you want to revisit the fundamentals or understand where these reflections come from, I highly recommend it: [Agentic Coding: concepts and hands-on use cases](/en/post/series/agentic_ai/ai-coding-agent/).
+These questions, as well as the methods that help me stay in control, are covered in the first article of this series. If you want to revisit the fundamentals or understand where these reflections come from, I highly recommend it: [Agentic Coding: concepts and hands-on use cases](/post/series/agentic_ai/ai-coding-agent/).
 
 ---
 
@@ -402,4 +402,4 @@ These questions, as well as the methods that help me stay in control, are covere
 - [Claude-Mem](https://github.com/thedotmack/claude-mem) — Persistent memory across sessions
 
 ### Previous article
-- [Agentic Coding: concepts and hands-on use cases](/en/post/series/agentic_ai/ai-coding-agent/) — Part 1 of the Agentic AI series
+- [Agentic Coding: concepts and hands-on use cases](/post/series/agentic_ai/ai-coding-agent/) — Part 1 of the Agentic AI series

--- a/content/en/post/series/agentic_ai/llm-self-hosted-stack/index.md
+++ b/content/en/post/series/agentic_ai/llm-self-hosted-stack/index.md
@@ -13,7 +13,7 @@ thumbnail = "thumbnail.png"
 +++
 
 {{% notice info "Agentic AI Series — Part 3" %}}
-This article follows [Agentic Coding: concepts and hands-on use cases](/en/post/series/agentic_ai/ai-coding-agent/) (the fundamentals of coding agents) and [A few months with Claude Code](/en/post/series/agentic_ai/ai-coding-tips/) (daily tips and lessons learned). **Here, we take a step back**: what can we reasonably do self-hosted today?
+This article follows [Agentic Coding: concepts and hands-on use cases](/post/series/agentic_ai/ai-coding-agent/) (the fundamentals of coding agents) and [A few months with Claude Code](/post/series/agentic_ai/ai-coding-tips/) (daily tips and lessons learned). **Here, we take a step back**: what can we reasonably do self-hosted today?
 {{% /notice %}}
 
 I now use agentic coding on a daily basis, like many of us. I'm overall happy with my Claude Code experience, but I keep a close eye on the **open-weight ecosystem**[^open-weight], which is also rapidly evolving: Qwen, Llama, Mistral, GLM, DeepSeek — and on the fierce competition between the various players in the space.
@@ -67,7 +67,7 @@ The whole thing is driven by **GitOps** (Flux reconciles everything from [`cloud
 
 ## :electric_plug: The centerpiece: the `InferenceService` abstraction
 
-If you've read some of [my previous articles](/en/post/crossplane_composition_functions/), you know I particularly like `Crossplane` for providing the right abstraction to end users. It's one of my essential components and lets me expose a **simple, fit-for-purpose interface**. I already have a few: `App`, `SQLInstance`, `EPI` — and now `InferenceService`.
+If you've read some of [my previous articles](/post/crossplane_composition_functions/), you know I particularly like `Crossplane` for providing the right abstraction to end users. It's one of my essential components and lets me expose a **simple, fit-for-purpose interface**. I already have a few: `App`, `SQLInstance`, `EPI` — and now `InferenceService`.
 
 ### Declaring a new model
 
@@ -112,7 +112,7 @@ From this _Claim_, about a dozen Kubernetes resources are created. Beyond the us
 
 * ⚡ **KEDA `ScaledObject`** — autoscaling triggered **before** load saturates a pod, rather than reacting to a queue forming. *([the math is detailed in Layer 2](#autoscaling-with-keda))*
 
-* 📊 **`VMServiceScrape` + `VMRule`** — vLLM metrics scraped by **VictoriaMetrics** on `/metrics`, SLOs and alerts (cold-start budget, error rate, latency) _shipped_ alongside the model. *([detailed approach in the Observability series](/en/post/series/observability/metrics/))*
+* 📊 **`VMServiceScrape` + `VMRule`** — vLLM metrics scraped by **VictoriaMetrics** on `/metrics`, SLOs and alerts (cold-start budget, error rate, latency) _shipped_ alongside the model. *([detailed approach in the Observability series](/post/series/observability/metrics/))*
 
 * 🚪 **`AIGatewayRoute`** — declares how the **Envoy AI Gateway** dispatches traffic to this model: `model: xplane-qwen-coder` in an OpenAI request lands on the right pod, with no application logic.
 
@@ -135,7 +135,7 @@ Four lines change. Flux reconciles, KEDA readjusts triggers, Karpenter provision
 {{% notice tip "KCL: version, test, validate a composition" %}}
 The composition isn't written as YAML patches (unreadable, untestable) but in [**KCL**](https://kcl-lang.io/) via the [function-kcl](https://github.com/crossplane-contrib/function-kcl) — a **typed** configuration language with **native assertions**. Three direct consequences:
 
-* **Unit tests** — a [`main_test.k`](https://github.com/Smana/cloud-native-ref/blob/wip/self-hosted-llm-platform-draft/infrastructure/base/crossplane/configuration/kcl/inference-service/main_test.k) file validates each behavior (`kcl test` runs in CI on every PR).
+* **Unit tests** — a [`main_test.k`](https://github.com/Smana/cloud-native-ref/blob/main/infrastructure/base/crossplane/configuration/kcl/inference-service/main_test.k) file validates each behavior (`kcl test` runs in CI on every PR).
 * **Versioned OCI packaging** — the composition is published as an OCI image (`oci://ghcr.io/smana/cloud-native-ref/crossplane-inference-service:0.6.0`), referenced by immutable tag.
 * **Claim schema validated at the API server** — `kubectl apply` rejects inconsistent claims (e.g. `minReplicas > maxReplicas`) **before** the composition is even triggered.
 
@@ -370,7 +370,7 @@ Each metric is automatically enriched with `gen_ai.*` labels (model, operation, 
 * **What's the prompt/generation ratio** per user? (useful for context sizing)
 * **How many chat vs embedding calls** per client?
 
-> The usual SLOs / alerts (p95 latency, error rate, GPU saturation) stay defined as `VMRule` next to that — nothing LLM-specific, I cover it in the [observability/alerting article](/en/post/series/observability/alerts/).
+> The usual SLOs / alerts (p95 latency, error rate, GPU saturation) stay defined as `VMRule` next to that — nothing LLM-specific, I cover it in the [observability/alerting article](/post/series/observability/alerts/).
 
 ### Qualitative evaluation with `Promptfoo`
 
@@ -425,7 +425,7 @@ Let's be clear: today I wouldn't trade my Claude ecosystem. Mainly for **financi
 
 That said, I would have liked to push my use of **OpenCode** further and migrate my Claude setup (skills, MCPs, sub-agents) onto that backend for good — that may be the topic of a future article dedicated to this open-source coding agent.
 
-But I'm keeping the stack alive. The day a Qwen3-Coder-30B-A3B runs cleanly on a quantized L4 — a path documented in [`docs/llm-platform-future-paths.md`](https://github.com/Smana/cloud-native-ref/blob/wip/self-hosted-llm-platform-draft/docs/llm-platform-future-paths.md) — the swap will be a few-line PR. That's the **main point** of this demo: positioning yourself to **move fast when the time comes**, rather than scrambling to (re)build everything the day open-weight catches up to the frontier.
+But I'm keeping the stack alive. The day a Qwen3-Coder-30B-A3B runs cleanly on a quantized L4 — a path documented in [`docs/llm-platform-future-paths.md`](https://github.com/Smana/cloud-native-ref/blob/main/docs/llm-platform-future-paths.md) — the swap will be a few-line PR. That's the **main point** of this demo: positioning yourself to **move fast when the time comes**, rather than scrambling to (re)build everything the day open-weight catches up to the frontier.
 
 And this catch-up isn't only about models: the open-source serving layer evolves just as fast and regularly brings in capabilities previously reserved for proprietary solutions. For instance, [**vLLM-Omni**](https://github.com/vllm-project/vllm-omni) (first stable late 2025) extends `vLLM` to **omni-modality** (text, image, audio, video, as **inputs and outputs**) with the same OpenAI-compatible API, so it plugs directly into the platform described here.
 
@@ -438,7 +438,7 @@ And this catch-up isn't only about models: the open-source serving layer evolves
 ### Repos
 - [`cloud-native-ref`](https://github.com/Smana/cloud-native-ref) — The complete platform
 - [`docs/decisions/`](https://github.com/Smana/cloud-native-ref/tree/main/docs/decisions) — ADRs (vLLM Production Stack, S3 Files…)
-- [`docs/llm-platform-future-paths.md`](https://github.com/Smana/cloud-native-ref/blob/wip/self-hosted-llm-platform-draft/docs/llm-platform-future-paths.md) — Evolution paths
+- [`docs/llm-platform-future-paths.md`](https://github.com/Smana/cloud-native-ref/blob/main/docs/llm-platform-future-paths.md) — Evolution paths
 
 ### Technical components
 - [vLLM Production Stack](https://github.com/vllm-project/production-stack) — Production-grade LLM inference
@@ -463,5 +463,5 @@ And this catch-up isn't only about models: the open-source serving layer evolves
 - [Huawei Ascend, Cambricon and Hygon Completed Day 0 Adaptation to DeepSeek-V4](https://www.trendforce.com/news/2026/04/29/news-huawei-ascend-cambricon-and-hygon-completed-day-0-adaptation-to-deepseek-v4/) — TrendForce
 
 ### Previous articles in the series
-- [Agentic Coding: concepts and hands-on use cases](/en/post/series/agentic_ai/ai-coding-agent/) — Part 1
-- [A few months with Claude Code: tips and workflows](/en/post/series/agentic_ai/ai-coding-tips/) — Part 2
+- [Agentic Coding: concepts and hands-on use cases](/post/series/agentic_ai/ai-coding-agent/) — Part 1
+- [A few months with Claude Code: tips and workflows](/post/series/agentic_ai/ai-coding-tips/) — Part 2

--- a/content/fr/post/series/agentic_ai/llm-self-hosted-stack/index.md
+++ b/content/fr/post/series/agentic_ai/llm-self-hosted-stack/index.md
@@ -135,7 +135,7 @@ Quatre lignes changent. Flux réconcilie, KEDA réajuste les triggers, Karpenter
 {{% notice tip "KCL : versionner, tester, valider une composition" %}}
 La composition n'est pas écrite en YAML patches (peu lisible, intestable) mais en [**KCL**](https://kcl-lang.io/) via la [function-kcl](https://github.com/crossplane-contrib/function-kcl) — un langage de configuration **typé**, avec **assertions natives**. Trois conséquences directes :
 
-* **Tests unitaires** — un fichier [`main_test.k`](https://github.com/Smana/cloud-native-ref/blob/wip/self-hosted-llm-platform-draft/infrastructure/base/crossplane/configuration/kcl/inference-service/main_test.k) valide chaque comportement (`kcl test` tourne en CI sur chaque PR).
+* **Tests unitaires** — un fichier [`main_test.k`](https://github.com/Smana/cloud-native-ref/blob/main/infrastructure/base/crossplane/configuration/kcl/inference-service/main_test.k) valide chaque comportement (`kcl test` tourne en CI sur chaque PR).
 * **Packaging OCI versionné** — la composition est publiée comme image OCI (`oci://ghcr.io/smana/cloud-native-ref/crossplane-inference-service:0.6.0`), référencée par tag immuable.
 * **Schéma de claim validé côté API server** — `kubectl apply` rejette les claims incohérentes (par exemple `minReplicas > maxReplicas`) **avant** que la composition ne se déclenche.
 
@@ -429,7 +429,7 @@ Soyons clairs : aujourd'hui je ne troquerais pas mon écosystème Claude. Princi
 
 Cela dit, j'aurais aimé pousser plus loin l'usage d'**OpenCode** et migrer pour de bon ma configuration Claude (skills, MCPs, sous-agents) sur ce backend — ce sera peut-être le sujet d'un futur article dédié à cet agent coding open-source.
 
-Mais je garde la stack vivante. Quand un Qwen3-Coder-30B-A3B tournera correctement sur un L4 quantifié — chemin documenté dans [`docs/llm-platform-future-paths.md`](https://github.com/Smana/cloud-native-ref/blob/wip/self-hosted-llm-platform-draft/docs/llm-platform-future-paths.md) — le swap sera une PR de quelques lignes. C'est ça l'**intérêt principal** de cette démo : se mettre en position d'**adopter rapidement** ce qui s'annonce, plutôt que d'avoir à tout (re)construire le jour où l'open-weight rattrapera le frontier.
+Mais je garde la stack vivante. Quand un Qwen3-Coder-30B-A3B tournera correctement sur un L4 quantifié — chemin documenté dans [`docs/llm-platform-future-paths.md`](https://github.com/Smana/cloud-native-ref/blob/main/docs/llm-platform-future-paths.md) — le swap sera une PR de quelques lignes. C'est ça l'**intérêt principal** de cette démo : se mettre en position d'**adopter rapidement** ce qui s'annonce, plutôt que d'avoir à tout (re)construire le jour où l'open-weight rattrapera le frontier.
 
 Et ce rattrapage ne vient pas que des modèles : la couche serving open-source évolue tout aussi vite et ajoute régulièrement des fonctions jusque-là réservées aux solutions propriétaires. Par exemple, [**vLLM-Omni**](https://github.com/vllm-project/vllm-omni) (premier *stable* fin 2025) étend `vLLM` à l'**omni-modalité** (texte, image, audio, vidéo, en entrée *et* en sortie) avec la même API OpenAI-compatible, donc plug directement dans la plateforme décrite ici.
 
@@ -442,7 +442,7 @@ Et ce rattrapage ne vient pas que des modèles : la couche serving open-source �
 ### Repos
 - [`cloud-native-ref`](https://github.com/Smana/cloud-native-ref) — La plateforme complète
 - [`docs/decisions/`](https://github.com/Smana/cloud-native-ref/tree/main/docs/decisions) — ADRs (vLLM Production Stack, S3 Files…)
-- [`docs/llm-platform-future-paths.md`](https://github.com/Smana/cloud-native-ref/blob/wip/self-hosted-llm-platform-draft/docs/llm-platform-future-paths.md) — Chemins d'évolution
+- [`docs/llm-platform-future-paths.md`](https://github.com/Smana/cloud-native-ref/blob/main/docs/llm-platform-future-paths.md) — Chemins d'évolution
 
 ### Composants techniques
 - [vLLM Production Stack](https://github.com/vllm-project/production-stack) — Inférence LLM en production


### PR DESCRIPTION
## Summary
- Fix 12 broken internal `/en/post/...` links across the EN versions of all three Agentic AI series articles — English is served at site root, so `/en/post/...` returns 404. Now `/post/...`.
- Fix 6 GitHub URLs pointing to the deleted `wip/self-hosted-llm-platform-draft` branch of `cloud-native-ref` — repointed to `main` (both referenced files still exist there).
- Add a "URL conventions" section to `CLAUDE.md` documenting that English is at root (`/post/...`), French is at `/fr/post/...`, and that `aliases = ["/en/post/..."]` are intentional redirects to leave alone.

## Test plan
- [ ] `hugo server` and click through each modified post: previous/next article links, in-text references, "Skills" cross-reference anchors, and References section
- [ ] Verify the two GitHub links in `llm-self-hosted-stack` (FR + EN) resolve: `main_test.k` and `llm-platform-future-paths.md`
- [ ] Confirm no `/en/post/` links remain in markdown body (kept only in `aliases` array): `grep -rE ']\(/en/post/' content/`