### PR TITLE
fix(blog): remove remote asciinema embed breaking CI builds

### DIFF
--- a/content/en/post/terraform-controller/index.md
+++ b/content/en/post/terraform-controller/index.md
@@ -163,8 +163,7 @@ NAME                             READY   STATUS    RESTARTS   AGE
 tf-controller-7ffdc69b54-c2brg   1/1     Running   0          2m6s
 ```
 
-In this demo, there are already a several AWS resources declared. Therefore, after a few minutes, the cluster takes care of creating these:
-[![asciicast](https://asciinema.org/a/guDIpkVdD51Cyog9P5NYnuWSq.png)](https://asciinema.org/a/guDIpkVdD51Cyog9P5NYnuWSq?&speed=2)
+In this demo, there are already a several AWS resources declared. Therefore, after a few minutes, the cluster takes care of creating these.
 
 {{% notice info Info %}}
 Although the majority of operations are performed declaratively or via the CLIs `kubectl` and `flux`, another tool allows to manage Terraform resources: [tfctl](https://docs.gitops.weave.works/docs/opentofu/tfctl/)

--- a/content/fr/post/terraform-controller/index.md
+++ b/content/fr/post/terraform-controller/index.md
@@ -163,8 +163,7 @@ NAME                             READY   STATUS    RESTARTS   AGE
 tf-controller-7ffdc69b54-c2brg   1/1     Running   0          2m6s
 ```
 
-Dans le repo de demo il y a déjà un certain nombre de ressources AWS déclarées. Par conséquent, au bout de quelques minutes, le cluster se charge de la création de celles-cis:
-[![asciicast](https://asciinema.org/a/guDIpkVdD51Cyog9P5NYnuWSq.png)](https://asciinema.org/a/guDIpkVdD51Cyog9P5NYnuWSq?&speed=2)
+Dans le repo de demo il y a déjà un certain nombre de ressources AWS déclarées. Par conséquent, au bout de quelques minutes, le cluster se charge de la création de celles-ci.
 
 {{% notice info Info %}}
 Bien que la majorité des tâches puisse être réalisée de manière déclarative ou via les utilitaires de ligne de commande tels que `kubectl` et `flux`, un autre outil existe qui offre la possibilité d'interagir avec les ressources terraform : [tfctl](https://docs.gitops.weave.works/docs/opentofu/tfctl/)


### PR DESCRIPTION
## Fix CI: remove the remote asciinema embed

The `github pages` build started failing on `main` (run after #94 merged):

```
render-image.html:21 → resources.GetRemote
Get "https://asciinema.org/a/…​.png": i/o timeout
```

### Root cause
Both `terraform-controller` posts (en + fr) embedded an **asciinema poster as a remote image**. The theme's `render-image.html` fetches every `http(s)` image at **build time** via `resources.GetRemote` with **no error handling**, so any transient failure reaching asciinema.org aborts the whole `hugo --minify`. Merging #94 changed `content/**`, which invalidated the CI Hugo-resource cache (`hashFiles('content/**', …)`) and forced a fresh fetch — which timed out. It was the **only remote image on the entire site**.

### Fix
Remove the asciinema embed from both posts (old post, the cast is expendable) and tidy the introductory sentence. No more build-time remote fetch → deterministic builds.

### Verification
`rm -rf resources/_gen && hugo --minify` builds **green** with the cache cleared (no remote fetch performed).
