### PR TITLE
docs(blog): RunLore post — 'PR fatigue' warning notice (FR/EN)

### DIFF
--- a/content/en/post/series/observability/runlore/index.md
+++ b/content/en/post/series/observability/runlore/index.md
@@ -127,6 +127,14 @@ RunLore takes a **deliberate stance**: keep a human at the center of the decisio
 
 And the agent never acts alone. The posture is _read-only → suggest → approve_: it reads, correlates, recommends; a human validates.
 
+{{% notice warning "Watch out for \"PR fatigue\" ⚠️" %}}
+The objection is fair: if nobody had time to document incidents yesterday, who will have the energy to review PRs the day after a crisis? The risk is real — either the PRs pile up and rot, or people hit "Merge" without reading, and the memory gets corrupted.
+
+Two answers. First, **the volume is bounded by design**: an incident that's already known produces **no PR at all** (it is served from the catalog), a duplicate is dropped, and an incident that already has an open PR gets a comment on it rather than a new one. Only a **new, verified, reliable enough** finding, with evidence and an action to back it, becomes a PR.
+
+Second, **don't review those PRs by hand as if they were prose**. The efficient move is to use an agent during the diagnosis phase itself: it cross-checks RunLore's proposal against what you understood while resolving the incident, enriches it with your context, and lets you work on several fronts at once. The human keeps the **decision** — not the line-by-line reading chore.
+{{% /notice %}}
+
 Keeping a human in the loop, on what gets done as much as on what gets learned, isn't a self-imposed limit. It's what makes the agent usable at all.
 
 ## 👀 Here's what it looks like

--- a/content/fr/post/series/observability/runlore/index.md
+++ b/content/fr/post/series/observability/runlore/index.md
@@ -127,6 +127,14 @@ RunLore a été construit avec un **parti pris assumé** : garder l'humain au c�
 
 Et l'agent n'agit jamais seul : la posture est _read-only → suggest → approve_ — il lit, corrèle, recommande ; un humain valide.
 
+{{% notice warning "Attention à la « PR fatigue » ⚠️" %}}
+L'objection est légitime : si personne n'avait le temps de documenter les incidents hier, qui aura l'énergie de relire des PRs le lendemain d'une crise ? Le risque est réel — soit les PRs s'accumulent, soit on clique « Merge » sans lire, et la mémoire se corrompt.
+
+Deux réponses. D'abord, **le volume est borné par construction** : un incident déjà connu ne produit **aucune PR** (il est servi depuis le catalogue), un doublon est écarté, et une PR déjà ouverte sur le même incident reçoit un commentaire plutôt qu'une nouvelle PR. Seul un finding **nouveau, vérifié et suffisamment fiable**, preuves et action à l'appui, devient une PR.
+
+Ensuite, **ne relis pas ces PRs à la main comme un document**. Le plus efficace est d'utiliser un agent pendant la phase de diagnostic elle-même : il recoupe la proposition de RunLore avec ce que tu as compris en résolvant l'incident, l'enrichit de ton contexte, et te permet de travailler sur plusieurs fronts. L'humain garde la **décision** — pas la corvée de lecture ligne à ligne.
+{{% /notice %}}
+
 Garder l'humain à la décision — sur ce qui est fait comme sur ce qui est appris — n'est pas une limite qu'on s'impose : c'est ce qui rend l'agent réellement utilisable.
 
 ## 👀 Voici ce que ça donne


### PR DESCRIPTION
Adds a warning notice to the human-in-the-loop section of the RunLore post, in both languages.

It answers the strongest critique of the design: if a team doesn't have the discipline to document incidents today, it won't have the energy to review AI-drafted PRs the day after a crisis — so the PRs either pile up or get rubber-stamped, corrupting the memory.

The notice makes two points, both grounded in what the code actually does:
- **The PR volume is bounded by design** — recalled findings are never curated (a known incident produces no PR), duplicates are dropped (fingerprint match + BM25 score), and an incident that already has an open PR gets a comment on it instead of a new PR. Only a new, verified finding above the confidence bar, with evidence and an action, becomes a PR.
- **Don't review those PRs by hand** — use an agent during the diagnosis phase to cross-check RunLore's draft against your own findings and enrich it with your context. The human keeps the decision, not the reading chore.