### PR TITLE
docs(blog): reframe the PR-fatigue notice as the bet, not a caveat

### DIFF
--- a/content/en/post/series/observability/runlore/index.md
+++ b/content/en/post/series/observability/runlore/index.md
@@ -127,12 +127,12 @@ RunLore takes a **deliberate stance**: keep a human at the center of the decisio
 
 And the agent never acts alone. The posture is _read-only → suggest → approve_: it reads, correlates, recommends; a human validates.
 
-{{% notice warning "Watch out for \"PR fatigue\" ⚠️" %}}
-The objection is fair: if nobody had time to document incidents yesterday, who will have the energy to review PRs the day after a crisis? The risk is real — either the PRs pile up and rot, or people hit "Merge" without reading, and the memory gets corrupted.
+{{% notice note "What about \"PR fatigue\"? 🤔" %}}
+The question comes up fast: if nobody had time to document incidents yesterday, who reviews these PRs tomorrow? That's RunLore's **bet**, and it's a deliberate one: the review isn't a chore you put up with, it's what separates a memory you own from a dump of LLM output.
 
-Two answers. First, **the volume is bounded by design**: an incident that's already known produces **no PR at all** (it is served from the catalog), a duplicate is dropped, and an incident that already has an open PR gets a comment on it rather than a new one. Only a **new, verified, reliable enough** finding, with evidence and an action to back it, becomes a PR.
+The bet holds because **the volume is bounded by design**: an incident that's already known produces **no PR at all** (it is served from the catalog), a duplicate is dropped, and an incident that already has an open PR gets a comment on it. Only a **new, verified, reliable enough** finding opens one.
 
-Second, **don't review those PRs by hand as if they were prose**. The efficient move is to use an agent during the diagnosis phase itself: it cross-checks RunLore's proposal against what you understood while resolving the incident, enriches it with your context, and lets you work on several fronts at once. The human keeps the **decision** — not the line-by-line reading chore.
+And nothing says you have to review by hand: the efficient move is to keep an agent in the loop **during** the diagnosis, cross-checking RunLore's draft against what you just worked out and enriching it with your context. You keep the **decision**, not the line-by-line reading.
 {{% /notice %}}
 
 Keeping a human in the loop, on what gets done as much as on what gets learned, isn't a self-imposed limit. It's what makes the agent usable at all.

--- a/content/fr/post/series/observability/runlore/index.md
+++ b/content/fr/post/series/observability/runlore/index.md
@@ -127,12 +127,12 @@ RunLore a été construit avec un **parti pris assumé** : garder l'humain au c�
 
 Et l'agent n'agit jamais seul : la posture est _read-only → suggest → approve_ — il lit, corrèle, recommande ; un humain valide.
 
-{{% notice warning "Attention à la « PR fatigue » ⚠️" %}}
-L'objection est légitime : si personne n'avait le temps de documenter les incidents hier, qui aura l'énergie de relire des PRs le lendemain d'une crise ? Le risque est réel — soit les PRs s'accumulent, soit on clique « Merge » sans lire, et la mémoire se corrompt.
+{{% notice note "Et la « PR fatigue » ? 🤔" %}}
+La question vient vite : si personne n'avait le temps de documenter les incidents hier, qui relira ces PRs demain ? C'est le **pari** de RunLore, et il est assumé : la relecture n'est pas une corvée qu'on subit, c'est ce qui distingue une mémoire dont on est propriétaire d'un dépotoir de sorties de LLM.
 
-Deux réponses. D'abord, **le volume est borné par construction** : un incident déjà connu ne produit **aucune PR** (il est servi depuis le catalogue), un doublon est écarté, et une PR déjà ouverte sur le même incident reçoit un commentaire plutôt qu'une nouvelle PR. Seul un finding **nouveau, vérifié et suffisamment fiable**, preuves et action à l'appui, devient une PR.
+Le pari tient parce que **le volume est borné par construction** : un incident déjà connu ne produit **aucune PR** (il est servi depuis le catalogue), un doublon est écarté, et une PR déjà ouverte sur le même incident reçoit un commentaire. Seul un finding **nouveau, vérifié et suffisamment fiable** en ouvre une.
 
-Ensuite, **ne relis pas ces PRs à la main comme un document**. Le plus efficace est d'utiliser un agent pendant la phase de diagnostic elle-même : il recoupe la proposition de RunLore avec ce que tu as compris en résolvant l'incident, l'enrichit de ton contexte, et te permet de travailler sur plusieurs fronts. L'humain garde la **décision** — pas la corvée de lecture ligne à ligne.
+Et rien n'oblige à relire à la main : le plus efficace est de garder un agent dans la boucle **pendant** le diagnostic, pour recouper la proposition de RunLore avec ce que tu viens de comprendre et l'enrichir de ton contexte. Tu gardes la **décision**, pas la lecture ligne à ligne.
 {{% /notice %}}
 
 Garder l'humain à la décision — sur ce qui est fait comme sur ce qui est appris — n'est pas une limite qu'on s'impose : c'est ce qui rend l'agent réellement utilisable.


### PR DESCRIPTION
Follow-up to #98, on review feedback.

The notice read as a **defence** — as if human review were a flaw to be excused. That gets the article backwards: the review *is* the premise. It is what separates a memory you own from a dump of LLM output, and the closing section already concedes the upfront effort honestly ("an investment, not an install-and-forget").

Reframed as a deliberate bet rather than an apology, in both languages. The substance (volume bounded by design; keep an agent in the loop during diagnosis rather than reading PRs line by line) is unchanged.

Also switched the notice from `warning` (which renders red) to `note` — this is a design trade-off, not a hazard.