### PR TITLE
docs(blog): runlore — surface the security posture in the try-it section

### DIFF
--- a/content/en/post/series/observability/runlore/index.md
+++ b/content/en/post/series/observability/runlore/index.md
@@ -267,18 +267,18 @@ All that's left is to route Alertmanager to `http://runlore.runlore.svc:8080/web
 
 The example above is a standard stack, but you can plug in whatever you want: **GitOps** (Flux/Argo CD), **metrics**, **logs**, **network flows**, **cloud**, several **LLMs** and **notifiers**, each one _pluggable_. The **full matrix**, which evolves with each release, lives in the [repo's README](https://github.com/Smana/runlore#-supported-integrations).
 
-### 🔒 What it's allowed to do, and what leaves your cluster
+### 🔒 Security wasn't an afterthought
 
-Wiring an LLM agent to your alerts raises two fair questions: **what can it break?** and **what gets sent to a third party?**
+Wiring an LLM agent to your alerts raises two fair questions: **what can it break?** and **what gets sent to a third party?** So security is where I've put the most care. Here's what matters:
 
-* **It changes nothing.** The chart's `ClusterRole` grants **no write permission**, and remediation actions are **off by default**: the model *proposes*, it doesn't *execute*. RunLore's only writes are **PRs** to your knowledge-base repo.
-* **Secrets are masked before they leave.** Keys, tokens, `user:pass@host` URLs, the `data:` block of a `kind: Secret` — even in the middle of a Git diff — are masked **before every call to the model**, then again before the PR and Slack. A mitigation, not a guarantee: an unlabeled high-entropy string will slip through.
-* **The model is treated as untrusted.** Its output is **data**, never an authorization. A prompt injection can bias a diagnosis; it doesn't trigger a write.
+* **It can't modify anything.** The chart's `ClusterRole` grants **no write permission**, and remediation actions are **off by default**: the model *proposes*, it doesn't *execute*. RunLore's only writes are **PRs** to your knowledge-base repo.
+* **Secrets are masked before they leave.** Keys, tokens, `user:pass@host` URLs, the `data:` block of a `kind: Secret` — even in the middle of a Git diff — are masked **before every call to the model**, then again before the PR and Slack.
+* **The model is treated as untrusted — because what it reads is untrusted too.** Logs, events, alert annotations: its context is full of text an attacker can influence. So its output is never a decision, only a proposal the server validates: a successful injection **degrades an answer, not your cluster**.
 * **And the rest of the groundwork**: least-privilege RBAC (raw logs are never readable cluster-wide), a non-root _Restricted_ pod, a NetworkPolicy, an authenticated webhook, a signed image with an SBOM.
 
-That leaves the number-one fear: *"my data goes to a third party"*. It has a simple answer — **nothing forces you to send it there**. `base_url` takes any OpenAI-compatible endpoint: point it at a **vLLM running in your own cluster** ([the self-hosted stack](/post/series/agentic_ai/llm-self-hosted-stack/)), and **nothing leaves your platform at all**.
+That leaves the number-one fear: *"my data goes to a third party"*. Here, **the choice is yours**. You're most likely already using an LLM day to day, and how sensitive your data really is depends on your context and on the trade-offs your company has already made.
 
-The full story — threat model and acknowledged limits — lives in [`docs/security-model.md`](https://github.com/Smana/runlore/blob/main/docs/security-model.md) and [`docs/security-architecture.md`](https://github.com/Smana/runlore/blob/main/docs/security-architecture.md).
+`base_url` takes any OpenAI-compatible endpoint: if you can afford it, point it at [a self-hosted stack](/post/series/agentic_ai/llm-self-hosted-stack/) and **nothing leaves your platform**. Not everyone can. If that's out of reach, you're left with the provider-side guardrails — **zero retention**, **no training on your data** — for whatever they're worth.
 
 {{% notice tip "A few tips to get started 💸" %}}
 An agent wired to Alertmanager can rack up LLM calls fast. You stay in control: start **deliberately low**, say **2 investigations/hour**, watch what happens, then raise the ceiling. The guardrails:

--- a/content/en/post/series/observability/runlore/index.md
+++ b/content/en/post/series/observability/runlore/index.md
@@ -267,6 +267,19 @@ All that's left is to route Alertmanager to `http://runlore.runlore.svc:8080/web
 
 The example above is a standard stack, but you can plug in whatever you want: **GitOps** (Flux/Argo CD), **metrics**, **logs**, **network flows**, **cloud**, several **LLMs** and **notifiers**, each one _pluggable_. The **full matrix**, which evolves with each release, lives in the [repo's README](https://github.com/Smana/runlore#-supported-integrations).
 
+### 🔒 What it's allowed to do, and what leaves your cluster
+
+Wiring an LLM agent to your alerts raises two fair questions: **what can it break?** and **what gets sent to a third party?**
+
+* **It changes nothing.** The chart's `ClusterRole` grants **no write permission**, and remediation actions are **off by default**: the model *proposes*, it doesn't *execute*. RunLore's only writes are **PRs** to your knowledge-base repo.
+* **Secrets are masked before they leave.** Keys, tokens, `user:pass@host` URLs, the `data:` block of a `kind: Secret` — even in the middle of a Git diff — are masked **before every call to the model**, then again before the PR and Slack. A mitigation, not a guarantee: an unlabeled high-entropy string will slip through.
+* **The model is treated as untrusted.** Its output is **data**, never an authorization. A prompt injection can bias a diagnosis; it doesn't trigger a write.
+* **And the rest of the groundwork**: least-privilege RBAC (raw logs are never readable cluster-wide), a non-root _Restricted_ pod, a NetworkPolicy, an authenticated webhook, a signed image with an SBOM.
+
+That leaves the number-one fear: *"my data goes to a third party"*. It has a simple answer — **nothing forces you to send it there**. `base_url` takes any OpenAI-compatible endpoint: point it at a **vLLM running in your own cluster** ([the self-hosted stack](/post/series/agentic_ai/llm-self-hosted-stack/)), and **nothing leaves your platform at all**.
+
+The full story — threat model and acknowledged limits — lives in [`docs/security-model.md`](https://github.com/Smana/runlore/blob/main/docs/security-model.md) and [`docs/security-architecture.md`](https://github.com/Smana/runlore/blob/main/docs/security-architecture.md).
+
 {{% notice tip "A few tips to get started 💸" %}}
 An agent wired to Alertmanager can rack up LLM calls fast. You stay in control: start **deliberately low**, say **2 investigations/hour**, watch what happens, then raise the ceiling. The guardrails:
 

--- a/content/fr/post/series/observability/runlore/index.md
+++ b/content/fr/post/series/observability/runlore/index.md
@@ -267,6 +267,19 @@ Il ne reste qu'à router les alertes d'Alertmanager vers `http://runlore.runlore
 
 L'exemple ci-dessus est une stack standard, mais tu peux brancher ce que tu veux — **GitOps** (Flux/Argo CD), **métriques**, **logs**, **flux réseau**, **cloud**, plusieurs **LLM** et **notifieurs**, chacun _pluggable_. La **matrice complète**, qui évolue au fil des versions, vit dans le [README du dépôt](https://github.com/Smana/runlore#-supported-integrations).
 
+### 🔒 Ce qu'il a le droit de faire, et ce qui sort de ton cluster
+
+Brancher un agent LLM sur ses alertes pose deux questions légitimes : **qu'est-ce qu'il peut casser ?** et **qu'est-ce qui part chez un tiers ?**
+
+* **Il ne modifie rien.** Le `ClusterRole` du chart n'accorde **aucun droit d'écriture**, et les actions correctives sont **désactivées par défaut** : le modèle *propose*, il n'*exécute* pas. Les seules écritures de RunLore sont des **PRs** dans ton dépôt de connaissances.
+* **Les secrets sont masqués avant de sortir.** Clés, tokens, URLs `user:pass@host`, blocs `data:` d'un `kind: Secret` — même au milieu d'un diff Git — sont masqués **avant chaque appel au modèle**, puis avant la PR et Slack. Une mitigation, pas une garantie : une chaîne à haute entropie sans étiquette passera entre les mailles.
+* **Le modèle est traité comme non fiable.** Sa sortie est de la **donnée**, jamais une autorisation. Une injection de prompt peut biaiser un diagnostic ; elle ne déclenche pas d'écriture.
+* **Et le reste du travail de fond** : RBAC minimal (les logs bruts ne sont jamais lisibles cluster-wide), pod _Restricted_ non-root, NetworkPolicy, webhook authentifié, image signée avec SBOM.
+
+Reste la crainte n°1 : *« mes données partent chez un tiers »*. Elle a une réponse simple — **rien ne t'y oblige**. `base_url` accepte n'importe quel endpoint OpenAI-compatible : pointe-le sur un **vLLM dans ton cluster** ([la stack self-hosted](/fr/post/series/agentic_ai/llm-self-hosted-stack/)), et **plus rien ne sort de ta plateforme**.
+
+Tout le détail — modèle de menace et limites assumées — vit dans [`docs/security-model.md`](https://github.com/Smana/runlore/blob/main/docs/security-model.md) et [`docs/security-architecture.md`](https://github.com/Smana/runlore/blob/main/docs/security-architecture.md).
+
 {{% notice tip "Quelques conseils pour bien démarrer 💸" %}}
 Un agent branché sur Alertmanager peut vite multiplier les appels LLM. Tu gardes la main : commence **volontairement bas** — par exemple **2 investigations/heure** — observe, puis desserre. Les garde-fous :
 

--- a/content/fr/post/series/observability/runlore/index.md
+++ b/content/fr/post/series/observability/runlore/index.md
@@ -267,18 +267,18 @@ Il ne reste qu'à router les alertes d'Alertmanager vers `http://runlore.runlore
 
 L'exemple ci-dessus est une stack standard, mais tu peux brancher ce que tu veux — **GitOps** (Flux/Argo CD), **métriques**, **logs**, **flux réseau**, **cloud**, plusieurs **LLM** et **notifieurs**, chacun _pluggable_. La **matrice complète**, qui évolue au fil des versions, vit dans le [README du dépôt](https://github.com/Smana/runlore#-supported-integrations).
 
-### 🔒 Ce qu'il a le droit de faire, et ce qui sort de ton cluster
+### 🔒 La sécurité, une contrainte de conception
 
-Brancher un agent LLM sur ses alertes pose deux questions légitimes : **qu'est-ce qu'il peut casser ?** et **qu'est-ce qui part chez un tiers ?**
+Brancher un agent LLM sur tes alertes pose deux questions légitimes : **qu'est-ce qu'il peut casser ?** et **qu'est-ce qui part chez un tiers ?** C'est pourquoi j'ai porté une attention particulière à la sécurité. En voici l'essentiel :
 
 * **Il ne modifie rien.** Le `ClusterRole` du chart n'accorde **aucun droit d'écriture**, et les actions correctives sont **désactivées par défaut** : le modèle *propose*, il n'*exécute* pas. Les seules écritures de RunLore sont des **PRs** dans ton dépôt de connaissances.
-* **Les secrets sont masqués avant de sortir.** Clés, tokens, URLs `user:pass@host`, blocs `data:` d'un `kind: Secret` — même au milieu d'un diff Git — sont masqués **avant chaque appel au modèle**, puis avant la PR et Slack. Une mitigation, pas une garantie : une chaîne à haute entropie sans étiquette passera entre les mailles.
-* **Le modèle est traité comme non fiable.** Sa sortie est de la **donnée**, jamais une autorisation. Une injection de prompt peut biaiser un diagnostic ; elle ne déclenche pas d'écriture.
+* **Les secrets sont masqués avant de sortir.** Clés, tokens, URLs `user:pass@host`, blocs `data:` d'un `kind: Secret` — même au milieu d'un diff Git — sont masqués **avant chaque appel au modèle**, puis avant la PR et Slack.
+* **Le modèle est traité comme non fiable — parce que ce qu'il lit l'est aussi.** Logs, events, annotations d'alertes : son contexte est rempli de texte qu'un attaquant peut influencer. Sa sortie n'est donc jamais une décision, seulement une proposition que le serveur valide : une injection réussie **dégrade une réponse, pas ton cluster**.
 * **Et le reste du travail de fond** : RBAC minimal (les logs bruts ne sont jamais lisibles cluster-wide), pod _Restricted_ non-root, NetworkPolicy, webhook authentifié, image signée avec SBOM.
 
-Reste la crainte n°1 : *« mes données partent chez un tiers »*. Elle a une réponse simple — **rien ne t'y oblige**. `base_url` accepte n'importe quel endpoint OpenAI-compatible : pointe-le sur un **vLLM dans ton cluster** ([la stack self-hosted](/fr/post/series/agentic_ai/llm-self-hosted-stack/)), et **plus rien ne sort de ta plateforme**.
+Reste la crainte n°1 : *« mes données partent chez un tiers »*. Ici, **le choix t'appartient**. Tu utilises probablement déjà un LLM au quotidien, et la sensibilité de tes données dépend de ton contexte et des arbitrages déjà faits dans ton entreprise.
 
-Tout le détail — modèle de menace et limites assumées — vit dans [`docs/security-model.md`](https://github.com/Smana/runlore/blob/main/docs/security-model.md) et [`docs/security-architecture.md`](https://github.com/Smana/runlore/blob/main/docs/security-architecture.md).
+`base_url` accepte n'importe quel endpoint OpenAI-compatible : si tu peux te le permettre, pointe-le vers [une stack self-hosted](/fr/post/series/agentic_ai/llm-self-hosted-stack/) et **plus rien ne sort de ta plateforme**. Tout le monde n'en a pas les moyens. À défaut, il reste les garde-fous côté fournisseur — **zéro rétention**, **pas d'entraînement sur tes données** — pour ce qu'ils valent.
 
 {{% notice tip "Quelques conseils pour bien démarrer 💸" %}}
 Un agent branché sur Alertmanager peut vite multiplier les appels LLM. Tu gardes la main : commence **volontairement bas** — par exemple **2 investigations/heure** — observe, puis desserre. Les garde-fous :


### PR DESCRIPTION
## Why

Feedback on the RunLore post: the **security work deserved to be visible** — a lot of it is implemented but none of it showed in the article. And the most common objection to an LLM agent wired to production alerts is *"my data goes to a third party"*, which the post never answered.

## What

A short `### 🔒` subsection in **"Try it yourself" / "Tu peux le tester simplement"** (EN + FR), just before the cost-guardrails tip:

- **It changes nothing** — no write verb in the `ClusterRole`, actions off by default; the only writes are KB PRs.
- **Secrets are masked before they leave** — redaction before every model call, then before the PR and Slack. Stated as a mitigation, not a guarantee.
- **The model is treated as untrusted** — its output is data, never an authorization.
- **The rest of the groundwork** in one line: least-privilege RBAC, non-root Restricted pod, NetworkPolicy, authenticated webhook, signed image + SBOM.
- Closes on the data-residency answer: `base_url` takes any OpenAI-compatible endpoint → **vLLM in your own cluster**, nothing leaves the platform. Links to the self-hosted stack post.

Deep-links to `docs/security-model.md` and `docs/security-architecture.md` for the full threat model.

## Accuracy

Every claim was checked against the RunLore repo (chart RBAC, `internal/redact`, `internal/action`, CI workflows). Deliberately **not** claimed: the NetworkPolicy ships enabled but is *not* default-deny on egress (`strict: true` is opt-in), so it's only listed, not sold as network isolation.

`hugo --minify` passes on both languages.