### PR TITLE
docs(blog): runlore — align text with updated Slack screenshots

### DIFF
--- a/content/en/post/series/observability/runlore/index.md
+++ b/content/en/post/series/observability/runlore/index.md
@@ -1,7 +1,7 @@
 +++
 author = "Smaine Kahlouch"
 title = "`RunLore`: the SRE buddy that investigates incidents — and learns from every fix"
-date = "2026-07-12"
+date = "2026-07-15"
 summary = "What you learn during an incident usually disappears the moment it's closed. RunLore is an open source SRE agent that investigates, points you at the likely root cause fast, and turns every resolution into knowledge you can reuse."
 featured = false
 codeMaxLines = 30
@@ -147,7 +147,7 @@ The whole demo runs on **GLM 5.2** (Zhipu AI, through Z.ai's OpenAI-compatible A
 
 ### 🔍 The incident
 
-A **`HarborRegistryDown`** alert fires. RunLore investigates and correlates several signals:
+A **`HarborRegistryCrashLooping`** alert fires. RunLore investigates and correlates several signals:
 
 * the **pod status**: `harbor-registry` is failing with `CreateContainerConfigError` — `couldn't find key username in Secret tooling/xplane-harbor-access-key`;
 * the **Kubernetes events** in the `tooling` namespace: a persistent Warning on the Crossplane resource `AccessKey/xplane-harbor` — `LimitExceeded: Cannot exceed quota for AccessKeysPerUser: 2`;
@@ -201,7 +201,7 @@ Some time later, the same incident **happens again**. This time RunLore runs **n
 
 {{< img src="runlore-recall.png" alt="Slack notification of an instant RunLore recall" width="760" >}}
 
-And it's **radically cheaper**: **~58,000 tokens** for the first investigation, **~3,700** for this recall. Same answer, in a matter of seconds.
+And it's **radically cheaper**: **~55,000 tokens** for the first investigation, **~3,700** for this recall. Same answer, in a matter of seconds.
 
 {{% notice info "How does recall find the right entry? 🎯" %}}
 Recall doesn't rely on keywords alone. Even when the alert shares **almost no wording** with the runbook that covers it, a **structural pre-filter** (the affected resource, here `tooling/harbor-registry`) narrows the candidates down first, then an **LLM reranker** judges whether the retrieved entry truly covers *this* resource and *this* symptom. And the cause is never taken for granted: it is **re-verified against the cluster's actual state** before publishing.

--- a/content/fr/post/series/observability/runlore/index.md
+++ b/content/fr/post/series/observability/runlore/index.md
@@ -1,7 +1,7 @@
 +++
 author = "Smaine Kahlouch"
 title = "`RunLore` : ton buddy SRE qui investigue les incidents — et apprend de chaque résolution"
-date = "2026-07-12"
+date = "2026-07-15"
 summary = "Souvent, la connaissance d'un incident se dissout dès qu'il est clos. RunLore, agent SRE open source, investigue et t'aide à identifier rapidement la root cause, puis transforme chaque résolution en savoir réutilisable."
 featured = false
 codeMaxLines = 30
@@ -147,7 +147,7 @@ Toute la démo tourne sur **GLM 5.2** (Zhipu AI, via l'API OpenAI-compatible de 
 
 ### 🔍 L'incident
 
-Une alerte **`HarborRegistryDown`** se déclenche. RunLore investigue et corrèle plusieurs signaux :
+Une alerte **`HarborRegistryCrashLooping`** se déclenche. RunLore investigue et corrèle plusieurs signaux :
 
 * le **statut du pod** : `harbor-registry` échoue en `CreateContainerConfigError` — `couldn't find key username in Secret tooling/xplane-harbor-access-key` ;
 * les **événements Kubernetes** du namespace `tooling` : un Warning persistant sur la ressource Crossplane `AccessKey/xplane-harbor` — `LimitExceeded: Cannot exceed quota for AccessKeysPerUser: 2` ;
@@ -201,7 +201,7 @@ Quelque temps plus tard, le même incident **se reproduit**. Cette fois, RunLore
 
 {{< img src="runlore-recall.png" alt="Notification Slack d'un rappel instantané RunLore" width="760" >}}
 
-Et c'est **radicalement moins cher** : **~58 000 tokens** pour la première investigation, **~3 700** pour ce rappel — même réponse, en quelques secondes.
+Et c'est **radicalement moins cher** : **~55 000 tokens** pour la première investigation, **~3 700** pour ce rappel — même réponse, en quelques secondes.
 
 {{% notice info "Comment le rappel retrouve-t-il la bonne entrée ? 🎯" %}}
 Le rappel ne se fie pas aux seuls mots-clés : même quand l'alerte n'a **presque aucun mot en commun** avec le runbook qui la couvre, un **pré-filtre structurel** (la ressource affectée — ici `tooling/harbor-registry`) réduit d'abord les candidats, puis un **reranker LLM** juge si l'entrée retrouvée couvre vraiment *cette* ressource et *ce* symptôme. Et la cause n'est jamais supposée : elle est **revérifiée contre l'état réel du cluster** avant publication.


### PR DESCRIPTION
- Alert name in the investigation section now matches the screenshot (HarborRegistryCrashLooping)
- First-investigation token count corrected to ~55,000
- Bump publish date