### PR TITLE
fix(search): restore lazy-loaded search bar

### DIFF
--- a/layouts/partials/search/scripts.html
+++ b/layouts/partials/search/scripts.html
@@ -8,8 +8,25 @@
   <script>
   (function () {
     var loaded = false;
-    var src = {{ $bundle.Permalink | jsonify }};
-    var integrity = {{ $bundle.Data.Integrity | jsonify }};
+    var src = {{ $bundle.Permalink }};
+    var integrity = {{ $bundle.Data.Integrity }};
+    function initSearchIndex() {
+      var lang = document.body.dataset.lang;
+      var slug = lang === defaultSiteLanguage ? '' : lang + '/';
+      var url = new URL(baseURL + slug + 'index.json').href;
+      fetch(url)
+        .then(function (response) { return response.json(); })
+        .then(function (data) {
+          initializeSearch(data && data.length ? data : []);
+          // The input listener attaches only now (init is lazy), so replay
+          // whatever the user already typed before the bundle finished loading.
+          var input = document.getElementById('find');
+          if (input && input.value) {
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+          }
+        })
+        .catch(function (error) { console.error(error); });
+    }
     function loadSearch() {
       if (loaded) return;
       loaded = true;
@@ -17,9 +34,25 @@
       s.src = src;
       s.integrity = integrity;
       s.crossOrigin = 'anonymous';
+      // search.js self-initializes on the window 'load' event. Because the
+      // bundle is fetched lazily (on focus/input), that event has usually
+      // already fired, so its own handler never runs — kick off init here.
+      s.onload = function () {
+        if (document.readyState === 'complete') {
+          initSearchIndex();
+        }
+        // Otherwise 'load' hasn't fired yet; search.js's own handler will run.
+      };
       document.head.appendChild(s);
     }
     document.addEventListener('DOMContentLoaded', function () {
+      // The dedicated search page renders results from the ?query= URL param
+      // via passiveSearch, so it needs the bundle immediately rather than on
+      // focus. Everywhere else, defer loading until the user intends to search.
+      if (document.getElementById('searchpage')) {
+        loadSearch();
+        return;
+      }
       var input = document.getElementById('find');
       if (input) {
         input.addEventListener('focus', loadSearch, { once: true });


### PR DESCRIPTION
## Problem

The site search was completely broken. The lazy-load rework in `8f554ae` ("perf: lazy-load search bundle") introduced **three** bugs in `layouts/partials/search/scripts.html`:

1. **Double-encoded asset URLs.** `{{ … | jsonify }}` inside a `<script>` block double-encodes, because Hugo's `html/template` already JS-escapes values in that context. `src`/`integrity` ended up wrapped in literal quotes (`"\"http://…\""`), so the bundle URL was malformed → **404** → the script never loaded.
2. **Init never fired.** `search.js` self-initializes on the `window` `load` event, but the bundle is now injected on first focus/input — *after* `load` has already fired — so its handler never ran. Typing did nothing.
3. **Dedicated `/search/` page broke.** It renders results from the `?query=` URL param via `passiveSearch`, which needs the bundle on page load, not on focus. Deep-links (search submit, result clicks) showed no results.

## Fix

- Drop the redundant `jsonify` — let Hugo's context-aware escaping produce clean JS strings.
- Kick off init from the script's `onload` (guarded by `readyState === 'complete'`), and replay the current input value since the listener attaches late.
- Eager-load the bundle on the `/search/` page (detected via `#searchpage`); keep lazy-loading everywhere else, preserving the original perf goal.

## Verification

Driven end-to-end in headless Chromium against a production build (cold cache):

| Flow | Result |
|------|--------|
| Live search (focus + type) — EN home, FR home, EN post list | ✅ 8 results each |
| Search page deep-link — `/search/?query=`, `/fr/search/?query=` | ✅ 12 results each |

The ~30 KB fuse+search bundle still only downloads when the user intends to search (or lands on the search page).