### PR TITLE
Record the switch from the in-house SDD workflow to Superpowers

### DIFF
--- a/content/en/post/series/agentic_ai/ai-coding-agent/index.md
+++ b/content/en/post/series/agentic_ai/ai-coding-agent/index.md
@@ -17,6 +17,10 @@ aliases = ["/en/post/ai-coding-agent/"]
 thumbnail = "thumbnail.png"
 +++
 
+{{% notice info "Update 2026-08-18" %}}
+After several months of using [Superpowers](https://github.com/obra/superpowers), I moved [cloud-native-ref](https://github.com/Smana/cloud-native-ref) over to it entirely: the in-house SDD variant described below is now retired. The reasoning behind it — platform constitution, review personas, verification against a real cluster — still holds; what changed is the mechanism. I cover this in [part 2 of the series](/post/series/agentic_ai/ai-coding-tips/).
+{{% /notice %}}
+
 We can all see it — AI is shaking things up in a major way. The field is evolving so fast that keeping up with every new development is nearly impossible. As for measuring the impact on our daily lives and how we work, it's still too early to tell. One thing is certain though: in tech, it's a **revolution**!
 
 In this post, I'll walk you through a practical application in **Platform Engineering**, exploring how a **coding agent** can help with common tasks in our field.
@@ -337,9 +341,11 @@ For those steeped in Kubernetes, here's an analogy 😉: the spec defines the **
 {{% /notice %}}
 
 {{% notice tip "My SDD variant for Platform Engineering" %}}
+> **Update 2026-08-18** — this in-house workflow has been replaced by [Superpowers](https://github.com/obra/superpowers). The section is kept as written: it describes what actually ran for several months.
+
 For [cloud-native-ref](https://github.com/Smana/cloud-native-ref), I created a variant inspired by GitHub Spec Kit that I'm evolving over time. I'll admit it's still quite experimental, but the results are already impressive.
 
-**🛡️ Platform Constitution** — Non-negotiable principles are codified in a [constitution](https://github.com/Smana/cloud-native-ref/blob/main/docs/specs/constitution.md): `xplane-*` prefix for IAM scoping, mandatory zero-trust networking, secrets via External Secrets only. Claude checks every spec and implementation against these rules.
+**🛡️ Platform Constitution** — Non-negotiable principles are codified in a [constitution](https://github.com/Smana/cloud-native-ref/blob/main/docs/platform-constitution.md): `xplane-*` prefix for IAM scoping, mandatory zero-trust networking, secrets via External Secrets only. Claude checks every spec and implementation against these rules.
 
 **👥 4 review personas** — Each spec goes through a checklist that forces you to consider multiple angles:
 
@@ -542,6 +548,7 @@ Given my affinity for open source, I'm looking at exploring open alternatives: *
 - [GitHub Spec Kit](https://github.com/github/spec-kit) — GitHub's SDD toolkit
 - [OpenSpec](https://github.com/Fission-AI/OpenSpec) — Lightweight SDD for brownfield projects
 - [BMAD Method](https://github.com/bmad-code-org/BMAD-METHOD) — Multi-agent SDD
+- [Superpowers](https://github.com/obra/superpowers) — The workflow I use today (Claude Code plugin)
 
 ### Plugins, Skills and MCPs
 - [Code-Simplifier](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier) — AI code cleanup

--- a/content/en/post/series/agentic_ai/ai-coding-tips/index.md
+++ b/content/en/post/series/agentic_ai/ai-coding-tips/index.md
@@ -25,6 +25,33 @@ This article will be updated as I discover new things and as tools evolve. Feel 
 
 ---
 
+## :wrench: How I currently use Claude Code
+
+Let's be honest: once you're used to Claude Code, expectations run high. I won't go over the concepts again here (MCP, skills, subagents, hooks, SDD, automode) — they're covered in the [first article of the series](/post/series/agentic_ai/ai-coding-agent/). Instead, here's a **non-exhaustive overview** of what I use daily and the **value** I get out of it:
+
+**The MCPs plugged into my session**
+
+* **Tolaria**: direct access to my personal wiki — notes, ADRs, lessons learned, retrieved without leaving the terminal
+* **Linear**: reading and creating tickets, linking a PR to an issue, without switching tabs
+* **VictoriaMetrics / VictoriaLogs**: querying metrics and logs from the agent, handy for debugging or correlating a behaviour with a deployment
+* **Flux**: checking a cluster's GitOps state (HelmReleases, Kustomizations) before acting
+* **Context7**: pulling up-to-date docs for a library or an SDK, to avoid hallucinations on recent APIs
+
+**Beyond MCPs**
+
+* **Skills**: specialized capabilities loaded on demand (creating PRs, security audits, writing designs)
+* **Subagents and hooks**: automatic triggers (desktop notification, pre-commit validation) and delegation to isolated contexts
+* **SDD** with **superpowers**: I tried several flavours (github-specs, gsd); this is the one I settled on, for how simple it is to use while still guaranteeing a complete workflow that respects good practices — [cloud-native-ref](https://github.com/Smana/cloud-native-ref) moved over to it entirely in August 2026
+* **Automode** on POCs, with a careful review of the first iteration before letting it run
+
+This workflow plays to **Claude's specific strengths**: Opus reasoning on the critical passages, the 1M context window in beta, and very reliable _function-calling_.
+
+{{% notice tip "Mise en abyme: this setup in action" %}}
+The [self-hosted LLM stack](/post/series/agentic_ai/llm-self-hosted-stack/) (part 3 of the series) was **entirely designed and built with Claude Code** — Crossplane/KCL compositions, Helm manifests, ADRs, Grafana dashboards, and the writing of the article itself. It's a concrete example of everything described here: MCPs (Tolaria for design notes, Context7 for the vLLM/KEDA docs, Flux to verify deployments), worktrees to parallelize the platform and the article, an SDD plan to frame the scope, and `code-simplifier` at the end of the cycle. A small irony: using Claude Code to build an alternative to Claude Code.
+{{% /notice %}}
+
+---
+
 ## :scroll: CLAUDE.md: persistent memory
 
 The `CLAUDE.md` file is the **first optimization lever**. These are instructions automatically injected into every conversation. If you don't have one yet, it's the first thing to set up.

--- a/content/fr/post/series/agentic_ai/ai-coding-agent/index.md
+++ b/content/fr/post/series/agentic_ai/ai-coding-agent/index.md
@@ -17,6 +17,10 @@ aliases = ["/fr/post/ai-coding-agent/"]
 thumbnail = "thumbnail.png"
 +++
 
+{{% notice info "Mise à jour 2026-08-18" %}}
+Après plusieurs mois à utiliser [Superpowers](https://github.com/obra/superpowers), j'ai basculé [cloud-native-ref](https://github.com/Smana/cloud-native-ref) entièrement dessus : la variante SDD maison décrite plus bas est désormais retirée. Le raisonnement qui la sous-tendait — constitution de plateforme, personas de review, vérification sur cluster réel — reste valable ; c'est le mécanisme qui a changé. J'en parle dans la [partie 2 de la série](/fr/post/series/agentic_ai/ai-coding-tips/).
+{{% /notice %}}
+
 Nous le voyons bien, nous assistons à un réel bouleversement provoqué par l'**utilisation de l'IA**. Ce domaine évolue à une telle vitesse qu'il devient presque impossible de suivre toutes les nouveautés. Quant à mesurer l'impact sur notre quotidien et notre façon de travailler, il est encore trop tôt pour le dire. Une chose est sûre cependant : dans la tech, c'est une **révolution** !
 
 Ici, je vais vous présenter une utilisation pratique dans le métier du **"Platform Engineering"** avec une exploration de l'utilisation d'un "**coding agent**" dans certaines tâches communes de notre métier.
@@ -336,9 +340,11 @@ Pour ceux qui baignent dans Kubernetes, on peut faire un parallèle 😉 : la sp
 {{% /notice %}}
 
 {{% notice tip "Ma variante SDD pour le Platform Engineering" %}}
+> **Mise à jour 2026-08-18** — ce workflow maison a été remplacé par [Superpowers](https://github.com/obra/superpowers). La section est conservée telle quelle : elle décrit ce qui a réellement tourné pendant plusieurs mois.
+
 Pour [cloud-native-ref](https://github.com/Smana/cloud-native-ref), j'ai créé une variante inspirée de GitHub Spec Kit que je fais évoluer progressivement. J'avoue que c'est assez expérimental pour le moment, mais les résultats sont déjà impressionnants.
 
-**🛡️ Platform Constitution** — Les principes non-négociables sont codifiés dans une [constitution](https://github.com/Smana/cloud-native-ref/blob/main/docs/specs/constitution.md) : préfixe `xplane-*` pour le scoping IAM, zero-trust networking obligatoire, secrets via External Secrets uniquement. Claude vérifie chaque spec et implémentation contre ces règles.
+**🛡️ Platform Constitution** — Les principes non-négociables sont codifiés dans une [constitution](https://github.com/Smana/cloud-native-ref/blob/main/docs/platform-constitution.md) : préfixe `xplane-*` pour le scoping IAM, zero-trust networking obligatoire, secrets via External Secrets uniquement. Claude vérifie chaque spec et implémentation contre ces règles.
 
 **👥 4 personas de review** — Chaque spec passe par une checklist qui force à considérer plusieurs angles :
 
@@ -541,6 +547,7 @@ De par ma sensibilité pour l'open source, j'envisage d'explorer les alternative
 - [GitHub Spec Kit](https://github.com/github/spec-kit) — Toolkit SDD de GitHub
 - [OpenSpec](https://github.com/Fission-AI/OpenSpec) — SDD léger pour projets brownfield
 - [BMAD Method](https://github.com/bmad-code-org/BMAD-METHOD) — Multi-agent SDD
+- [Superpowers](https://github.com/obra/superpowers) — Le workflow que j'utilise aujourd'hui (plugin Claude Code)
 
 ### Plugins, Skills et MCPs
 - [Code-Simplifier](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier) — Nettoyage de code IA

--- a/content/fr/post/series/agentic_ai/ai-coding-tips/index.md
+++ b/content/fr/post/series/agentic_ai/ai-coding-tips/index.md
@@ -20,7 +20,7 @@ Cet article fait suite à [Agentic Coding : concepts et cas concrets](/fr/post/s
 Comme pour tout outil qu'on adopte, c'est avec le temps qu'on affine sa façon de l'utiliser. À force d'itérer sur ma config et mes workflows, j'ai trouvé un rythme efficace avec Claude Code. Je partage ici ce qui fonctionne pour moi.
 
 {{% notice info "Article vivant" %}}
-**Dernière mise à jour : 9 mai 2026**
+**Dernière mise à jour : 18 août 2026**
 
 Cet article est mis à jour régulièrement au fil de mes découvertes et de l'évolution des outils. N'hésitez pas à revenir de temps en temps pour y trouver de nouveaux tips.
 {{% /notice %}}
@@ -43,7 +43,7 @@ Autant le dire : quand on est habitué à Claude Code, les attentes sont élevé
 
 * **Skills** : capacités spécialisées chargées à la demande (création de PRs, audits sécurité, écriture de specs)
 * **Subagents et hooks** : déclencheurs automatiques (notification desktop, validation pré-commit) et délégation à des contextes isolés
-* **SDD** avec **superpowers** : j'ai testé plusieurs déclinaisons (github-specs, gsd) ; c'est aujourd'hui mon préféré pour sa simplicité d'usage, tout en garantissant un workflow complet qui respecte les bonnes pratiques
+* **SDD** avec **superpowers** : j'ai testé plusieurs déclinaisons (github-specs, gsd) ; c'est celui que j'ai retenu, pour sa simplicité d'usage tout en garantissant un workflow complet qui respecte les bonnes pratiques — [cloud-native-ref](https://github.com/Smana/cloud-native-ref) a entièrement basculé dessus en août 2026
 * **Automode** sur les POC, avec une revue minutieuse à la première itération avant de laisser tourner
 
 Ce workflow tire parti des **forces spécifiques de Claude** : raisonnement Opus sur les passages critiques, fenêtre de contexte 1M en bêta, _function-calling_ très fiable.


### PR DESCRIPTION
## Summary

`cloud-native-ref` switched from its in-house Spec-Driven Development workflow to [Superpowers](https://github.com/obra/superpowers) ([Smana/cloud-native-ref#1764](https://github.com/Smana/cloud-native-ref/pull/1764), merged 2026-08-18). Two articles in the *Agentic AI* series document the old workflow; this brings them up to date.

## Changes

**`ai-coding-agent` (FR + EN)** — the article carrying the "My SDD variant for Platform Engineering" section, with its constitution, four review personas, `/spec` `/clarify` `/validate` skill table and eight screenshots.

- An `Update 2026-08-18` notice after the front matter, matching the convention already used in `terraform-controller` and `crossplane_composition_functions`.
- A short line inside the "My SDD variant" notice, so a reader arriving mid-article from a search result is not misled.
- The section body is **not** rewritten. It remains an accurate account of what was built and ran for months, and the reasoning behind it — platform constitution, review personas, verification against a real cluster — survived the switch. Only the mechanism changed.
- The constitution link is repointed from `docs/specs/constitution.md` to `docs/platform-constitution.md`, which the migration moved. Verified against `main`: the new path resolves, the old one 404s.
- Superpowers added to the article's "Spec-Driven Development" reference list, which named Spec Kit, OpenSpec and BMAD but not the tool that actually won.

**`ai-coding-tips`** — the French version already said Superpowers was the preferred SDD flavour; the English translation was missing the article's entire opening section (`## Mon utilisation actuelle de Claude Code`), so an English reader never saw it.

- That section is translated and inserted into the English post — MCP list, skills / subagents / SDD bullets, and the *mise en abyme* notice. Both languages now report 13 `##` sections.
- The SDD bullet in both languages now records the completed switch rather than a current preference.
- French "Article vivant" date refreshed to 18 août 2026.

## Validation

- `hugo --gc --minify` → exit 0, 89 EN / 67 FR pages, no shortcode errors.
- Both notices render in both languages; the rendered output contains `docs/platform-constitution.md` and no `docs/specs/constitution.md`.
