### PR TITLE
fix(pages): drop the trailing dot from static/CNAME

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-blog.ogenki.io.
+blog.ogenki.io


### PR DESCRIPTION
## The outage

`blog.ogenki.io` is currently serving **404** on every path. `smana.github.io` serves the site fine, and `GET /repos/Smana/smana.github.io/pages` reports `"cname": null` — GitHub Pages has **no custom domain set**.

## Cause

`static/CNAME` contains `blog.ogenki.io.` — with a **trailing dot**. Pages rejects that as a custom domain and silently clears the setting.

The dot has been there since `890318e` (the original Actions setup). The `gh-pages` copy was corrected by hand in `228d44d` ("Update CNAME", Aug 19), but the source file was never touched — so the next deploy from `main` copied the bad value straight back over the fix.

| gh-pages commit | `CNAME` bytes | Custom domain |
|---|---|---|
| `228d44d` (Aug 19, manual fix) | `blog.ogenki.io` | working |
| `5a5bd14` (deploy of `7d876fe`) | `blog.ogenki.io.\n` | **dropped** |

## Fix

Correct `static/CNAME` at the source so the fix survives future deploys. The file is now byte-identical to the working `228d44d` version (14 bytes, no trailing dot, no newline), and `hugo --minify` emits it verbatim to `public/CNAME`.

## Note: merging this is not sufficient on its own

Pages has already cleared the custom domain. Deploying a correct `CNAME` file should re-establish it, but if it does not, the domain has to be re-set once in **Settings → Pages → Custom domain** (`blog.ogenki.io`), after which this fix keeps it from being clobbered again.